### PR TITLE
feat: add no-notes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,13 @@ notes: this is a human friendly sentence about what this PR does
 notes: removed upstream code that used private Mac APIs
 ```
 
-
 ```markdown
 notes: fixed issue where electron crashes on exit
+```
+
+To tell `clerk` that this PR has no user-facing changes and should not be
+included in release notes:
+
+```markdown
+notes: no-notes
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,16 @@
 import { Application, Context } from 'probot';
 import { WebhookPayloadWithRepository } from 'probot/lib/context'
 
+const OMIT_FROM_RELEASE_NOTES_KEY = 'no-notes';
+
 const getReleaseNotes = (pr: WebhookPayloadWithRepository["pull_request"]) => {
   const currentPRBody = pr.body;
 
   const releaseNotesMatch = /(?:(?:\r?\n)|^)notes: (.+?)(?:(?:\r?\n)|$)/gi.exec(currentPRBody);
-  if (!releaseNotesMatch) return null;
 
-  return releaseNotesMatch[1] || null;
+  if (!releaseNotesMatch || !releaseNotesMatch[1]) return null;
+  let note = releaseNotesMatch[1].trim();
+  return note !== OMIT_FROM_RELEASE_NOTES_KEY ? note : null;
 };
 
 const submitFeedbackForPR = async (

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,11 +6,9 @@ const OMIT_FROM_RELEASE_NOTES_KEY = 'no-notes';
 const getReleaseNotes = (pr: WebhookPayloadWithRepository["pull_request"]) => {
   const currentPRBody = pr.body;
 
-  const releaseNotesMatch = /(?:(?:\r?\n)|^)notes: (.+?)(?:(?:\r?\n)|$)/gi.exec(currentPRBody);
+  const notesMatch = /(?:(?:\r?\n)|^)notes: (.+?)(?:(?:\r?\n)|$)/gi.exec(currentPRBody);
 
-  if (!releaseNotesMatch || !releaseNotesMatch[1]) return null;
-  let note = releaseNotesMatch[1].trim();
-  return note !== OMIT_FROM_RELEASE_NOTES_KEY ? note : null;
+  return notesMatch && notesMatch[1] ? notesMatch[1] : null;
 };
 
 const submitFeedbackForPR = async (
@@ -37,7 +35,7 @@ const submitFeedbackForPR = async (
   }
 
   if (shouldComment) {
-    if (releaseNotes) {
+    if (releaseNotes && (releaseNotes !== OMIT_FROM_RELEASE_NOTES_KEY)) {
       await context.github.issues.createComment(context.repo({
         number: pr.number,
         body: `**Release Notes Persisted**


### PR DESCRIPTION
This addes a `notes: no-notes` option to codify the idiom Jeremy used in https://github.com/electron/electron/pull/14093

Introduces no new failures to `yarn test` so this should be G2G.