### PR TITLE
fix: ensure users didn't leave PR template

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,13 +8,14 @@ const getReleaseNotes = (pr: WebhookPayloadWithRepository["pull_request"]) => {
 
   const re = new RegExp(`(?:(?:\r?\n)|^)notes: (.+?)(?:(?:\r?\n)|$)`, 'gi');
   const notesMatch = currentPRBody.match(re);
-  
+
+  const notes = notesMatch && notesMatch[1] ? notesMatch[1] : null;
+
   // check that they didn't leave the default PR template
-  if (notesMatch === 'Notes: <!-- One-line Change Summary Here-->') {
-    return false;
-  } else {
-    return notesMatch && notesMatch[1] ? notesMatch[1] : null;
+  if (notes === 'Notes: <!-- One-line Change Summary Here-->') {
+    return null;
   }
+  return notes;
 };
 
 const submitFeedbackForPR = async (

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,15 @@ const OMIT_FROM_RELEASE_NOTES_KEY = 'no-notes';
 const getReleaseNotes = (pr: WebhookPayloadWithRepository["pull_request"]) => {
   const currentPRBody = pr.body;
 
-  const notesMatch = /(?:(?:\r?\n)|^)notes: (.+?)(?:(?:\r?\n)|$)/gi.exec(currentPRBody);
-
-  return notesMatch && notesMatch[1] ? notesMatch[1] : null;
+  const re = new RegExp(`(?:(?:\r?\n)|^)notes: (.+?)(?:(?:\r?\n)|$)`, 'gi');
+  const notesMatch = currentPRBody.match(re);
+  
+  // check that they didn't leave the default PR template
+  if (notesMatch === 'Notes: <!-- One-line Change Summary Here-->') {
+    return false;
+  } else {
+    return notesMatch && notesMatch[1] ? notesMatch[1] : null;
+  }
 };
 
 const submitFeedbackForPR = async (


### PR DESCRIPTION
This PR ensures that when users leave the default `Release Notes` section in PR templates on `electron/electron`, `clerk` fails to pass the check.

/cc @MarshallOfSound 