### PR TITLE
chore: add more options for 'no-notes'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,11 @@
 import { Application, Context } from 'probot';
 import { WebhookPayloadWithRepository } from 'probot/lib/context';
 
-const OMIT_FROM_RELEASE_NOTES_KEY = 'no-notes';
+const OMIT_FROM_RELEASE_NOTES_KEYS = [
+  'no-notes',
+  'no notes',
+  'no_notes',
+];
 
 const getReleaseNotes = (pr: WebhookPayloadWithRepository['pull_request']) => {
   const currentPRBody = pr.body;
@@ -40,7 +44,7 @@ const submitFeedbackForPR = async (
   }
 
   if (shouldComment) {
-    if (releaseNotes && (releaseNotes !== OMIT_FROM_RELEASE_NOTES_KEY)) {
+    if (releaseNotes && (OMIT_FROM_RELEASE_NOTES_KEYS.indexOf(releaseNotes) === -1)) {
       await context.github.issues.createComment(context.repo({
         number: pr.number,
         body: `**Release Notes Persisted**


### PR DESCRIPTION
I've noticed a few people typo'ing this with a space or an underscore, instead of insisting people spell it "correctly", let's just allow a few other ways of writing "no notes" 😄 