### PR TITLE
fix: remove any markdown comments from persisted notes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,12 @@ const submitFeedbackForPR = async (
       let notes: string;
       if (splitNotes.length > 0) {
         notes = splitNotes.map(line => `> ${line}`).join('\n');
+
+        // remove any markdown comments
+        const commentMatch = /<!--.*-->/g.exec(notes);
+        if (commentMatch && commentMatch[0]) {
+          notes = notes.replace(commentMatch[0], '');
+        }
       } else {
         notes = '> No Release';
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,10 +65,7 @@ const submitFeedbackForPR = async (
         notes = splitNotes.map(line => `> ${line}`).join('\n');
 
         // remove any markdown comments
-        const commentMatch = /<!--.*-->/g.exec(notes);
-        if (commentMatch && commentMatch[0]) {
-          notes = notes.replace(commentMatch[0], '');
-        }
+        notes = notes.replace(/<!--.*?-->/g, '');
       } else {
         notes = '> No Release';
       }


### PR DESCRIPTION
Fixes an issue with markdown comments being persisted and messing with the release notes.

Before:
```js
{
  "body": "**Release Notes Persisted**\n\n> <!-- One-line Change Summary Here--> improved tray icon context menu and menu bar accessibility"
}
```
After: 
```js
{
  "body": "**Release Notes Persisted**\n\n>  improved tray icon context menu and menu bar accessibility"
}
```

cc @ckerr 