### PR TITLE
feat: add target version to PR comments [wip]

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,14 @@
   "license": "MIT",
   "dependencies": {
     "@octokit/rest": "^15.9.5",
-    "probot": "^7.0.1"
+    "probot": "^7.0.1",
+    "semver": "^5.6.0"
   },
   "devDependencies": {
     "@types/bunyan": "^1.8.4",
     "@types/jest": "^23.3.5",
     "@types/node": "^10.7.0",
+    "@types/semver": "^5.5.0",
     "jest": "^23.6.0",
     "ts-jest": "^23.10.5",
     "tslint": "^5.11.0",

--- a/src/__tests__/note.test.ts
+++ b/src/__tests__/note.test.ts
@@ -13,27 +13,42 @@ describe('note detection', () => {
 describe('comment generation', () => {
   it('knows when to show notes', () => {
     const note = 'some note';
-    const comment = noteUtils.createPRCommentFromNotes(note);
+    const comment = noteUtils.createPRCommentFromNotes(note, ['1.2.3']);
     expect(comment).toEqual(expect.stringContaining(constants.NOTES_LEAD));
     expect(comment).toEqual(expect.stringContaining(note));
   });
 
   it('knows when to show no-notes', () => {
-    expect(noteUtils.createPRCommentFromNotes('no-notes')).toEqual(constants.NO_NOTES_BODY);
+    expect(noteUtils.createPRCommentFromNotes('no-notes', ['1.2.3']))
+      .toEqual(constants.NO_NOTES_BODY);
   });
 
   it('quotes a single-line note', () => {
     const note = 'some note';
-    const comment = noteUtils.createPRCommentFromNotes(note);
+    const comment = noteUtils.createPRCommentFromNotes(note, ['1.2.3']);
     expect(comment).toEqual(expect.stringContaining(constants.NOTES_LEAD));
     expect(comment).toEqual(expect.stringContaining(`> ${note}`));
   });
 
   it('quotes a multiline note', () => {
     const note = 'line one\nline two';
-    const comment = noteUtils.createPRCommentFromNotes(note);
+    const comment = noteUtils.createPRCommentFromNotes(note, ['1.2.3']);
     expect(comment).toEqual(expect.stringContaining(constants.NOTES_LEAD));
     expect(comment).toEqual(expect.stringContaining('> line one\n> line two'));
+  });
+
+  it('includes the version', () => {
+    const note = 'some note';
+    const comment = noteUtils.createPRCommentFromNotes(note, ['1.2.3']);
+    expect(comment).toEqual(expect.stringContaining(constants.NOTES_LEAD));
+    expect(comment).toEqual(expect.stringContaining('Version: 1.2.3'));
+  });
+
+  it('includes multiple versions', () => {
+    const note = 'some note';
+    const comment = noteUtils.createPRCommentFromNotes(note, ['1.2.3-beta.1', '1.2.3']);
+    expect(comment).toEqual(expect.stringContaining(constants.NOTES_LEAD));
+    expect(comment).toEqual(expect.stringContaining('Version: 1.2.3-beta.1, 1.2.3'));
   });
 });
 

--- a/src/__tests__/pr.test.ts
+++ b/src/__tests__/pr.test.ts
@@ -1,0 +1,15 @@
+import { getTargetVersions } from '../pr';
+
+describe('target versions', () => {
+  it('bumps patch', () => {
+    expect(getTargetVersions('4.0.4')).toEqual(['4.0.5']);
+    expect(getTargetVersions('3.1.0')).toEqual(['3.1.1']);
+  });
+  it('targets beta.n+1 + release for prs against a beta branch', () => {
+    expect(getTargetVersions('5.0.0-beta.1')).toEqual(['5.0.0-beta.2', '5.0.0']);
+    expect(getTargetVersions('3.1.0-beta.4')).toEqual(['3.1.0-beta.5', '3.1.0']);
+  });
+  it('targets beta.1 + release for prs against a nightly branch', () => {
+    expect(getTargetVersions('6.0.0-nightly.20190214')).toEqual(['6.0.0-beta.1', '6.0.0']);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { Application, Context } from 'probot';
 import { WebhookPayloadWithRepository } from 'probot/lib/context';
 import * as noteUtils from './note-utils';
+import { getTargetVersionsForPr } from './pr';
 
 const submitFeedbackForPR = async (
   context: Context,
@@ -26,8 +27,9 @@ const submitFeedbackForPR = async (
   }
 
   if (shouldComment) {
+    const targetVersions = await getTargetVersionsForPr(context, pr);
     await context.github.issues.createComment(context.repo({
-      body: noteUtils.createPRCommentFromNotes(releaseNotes),
+      body: noteUtils.createPRCommentFromNotes(releaseNotes, targetVersions),
       number: pr.number,
     }));
   }

--- a/src/note-utils.ts
+++ b/src/note-utils.ts
@@ -33,13 +33,18 @@ const OMIT_FROM_RELEASE_NOTES_KEYS = [
   'nothing',
 ];
 
-export const createPRCommentFromNotes = (releaseNotes: string | null) => {
+export const createPRCommentFromNotes = (releaseNotes: string | null, targetVersion: string[]) => {
   let body = constants.NO_NOTES_BODY;
   if (releaseNotes && (OMIT_FROM_RELEASE_NOTES_KEYS.indexOf(releaseNotes) === -1)) {
     const splitNotes = releaseNotes.split('\n').filter(line => line !== '');
     if (splitNotes.length > 0) {
       const quoted = splitNotes.map(line => `> ${line}`).join('\n');
-      body = `${constants.NOTES_LEAD}\n\n${quoted}`;
+      body = [
+        constants.NOTES_LEAD,
+        '',
+        `Version: ${targetVersion.join(', ')}`,
+        `Notes:\n${quoted}`,
+      ].join('\n');
     }
   }
 

--- a/src/pr.ts
+++ b/src/pr.ts
@@ -1,0 +1,34 @@
+import { Context } from 'probot';
+import { WebhookPayloadWithRepository } from 'probot/lib/context';
+import * as semver from 'semver';
+
+export function getTargetVersions(version: string): string[] {
+  const prerelease = semver.prerelease(version);
+  const [release] = version.split('-');
+  return prerelease
+    ? prerelease[0] === 'nightly'
+      ? [`${release}-beta.1`, release]
+      : [semver.inc(version, 'prerelease'), release]
+    : [semver.inc(version, 'patch')];
+}
+
+async function getPackageJsonForRef(context: Context, ref: string) {
+  const packageJsonResp = await context.github.repos.getContent(context.repo({
+    ref,
+    path: 'package.json',
+  }));
+  return JSON.parse(Buffer.from(packageJsonResp.data.content, 'base64').toString('utf8'));
+}
+
+export async function getTargetVersionsForPr(
+  context: Context,
+  pr: WebhookPayloadWithRepository['pull_request'],
+): Promise<string[]> {
+  const packageJson = await getPackageJsonForRef(context, pr.head.sha);
+  const version = semver.valid(packageJson.version);
+  if (!version) {
+    throw new Error(`Couldn't find version in package.json. ` +
+      `Expected valid semver string but found '${packageJson.version}'.`);
+  }
+  return getTargetVersions(version);
+}


### PR DESCRIPTION
marking this as wip because release-notes.js will probably need to be updated to deal with this.

This is the first step towards realising the [proposal](https://docs.google.com/document/d/1Z65bF4ixcgD3ISk0Cg0c0xDQF-VV5_zcJHCG-73-8bc/edit#) for making clerk's PR comments the single source of truth for all release notes.