### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global File Owners
-* @MarshallOfSound @codebytere @zeke
+@electron/wg-releases


### PR DESCRIPTION
This repo is owned by the Releases WG - ergo it should be the CODEOWNERS for this repo.

cc @electron/wg-releases 