### PR TITLE
fix: no-note matching with punctuation

### DIFF
--- a/src/__tests__/note.test.ts
+++ b/src/__tests__/note.test.ts
@@ -19,7 +19,18 @@ describe('comment generation', () => {
   });
 
   it('knows when to show no-notes', () => {
+    const note = noteUtils.findNoteInPRBody(prBodyWithNoNote);
+    expect(noteUtils.createPRCommentFromNotes(note)).toEqual(constants.NO_NOTES_BODY);
+
     expect(noteUtils.createPRCommentFromNotes('no-notes')).toEqual(constants.NO_NOTES_BODY);
+  });
+
+  it('does not false positively match no-notes', () => {
+    const surpriseNote = noteUtils.findNoteInPRBody(prBodyWithSurpriseNote);
+    const comment = noteUtils.createPRCommentFromNotes(surpriseNote);
+
+    expect(comment).toEqual(expect.stringContaining(constants.NOTES_LEAD));
+    expect(comment).toEqual(expect.stringContaining('> no-notes but actually a note.'));
   });
 
   it('quotes a single-line note', () => {
@@ -68,5 +79,40 @@ See that PR for details.
 
 
 Notes: <!-- Please add a one-line description for app developers to read in the release notes, or \`no-notes\` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
+`;
+/* tslint:enable */
+
+// source: https://github.com/electron/electron/pull/25112
+/* tslint:disable */
+const prBodyWithNoNote = `#### Description of Change
+
+Fixes an issue where interacting with a BrowserWindow which had a BrowserView attached whose \`webContents\` had been destroyed could cause a crash in \`BaseWindow::ResetBrowserViews()\`.
+
+cc @nornagon @MarshallOfSound 
+
+#### Checklist
+<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
+
+- [x] PR description included and stakeholders cc'd
+- [x] \`npm test\` passes
+- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
+- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
+- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
+- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.
+
+#### Release Notes
+
+Notes: none.
+`;
+/* tslint:enable */
+
+/* tslint:disable */
+const prBodyWithSurpriseNote = `#### Description of Change
+
+Fixes something!
+
+cc @nornagon @MarshallOfSound 
+
+Notes: no-notes but actually a note.
 `;
 /* tslint:enable */

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ const submitFeedbackForPR = async (context: Context, pr: any, shouldComment = fa
 };
 
 const probotRunner = (app: Application) => {
-  app.on('pull_request', async context => {
+  app.on('pull_request', async (context) => {
     const pr = context.payload.pull_request;
 
     if (context.payload.action === 'closed' && pr.merged) {

--- a/src/note-utils.ts
+++ b/src/note-utils.ts
@@ -26,21 +26,21 @@ export const findNoteInPRBody = (body: string): string | null => {
 };
 
 const OMIT_FROM_RELEASE_NOTES_KEYS = [
-  'blank',
-  'empty',
-  'no notes',
-  'no',
-  'no-notes',
-  'no_notes',
-  '`no-notes`',
-  '`no notes`',
-  'none',
-  'nothing',
+  /^blank.?$/,
+  /^empty.?$/,
+  /^no notes.?$/,
+  /^no.?$/,
+  /^no-notes.?$/,
+  /^no_notes.?$/,
+  /^`no-notes.?$`/,
+  /^`no notes.?$`/,
+  /^none.?$/,
+  /^nothing.?$/,
 ];
 
 export const createPRCommentFromNotes = (releaseNotes: string | null) => {
   let body = constants.NO_NOTES_BODY;
-  if (releaseNotes && OMIT_FROM_RELEASE_NOTES_KEYS.indexOf(releaseNotes) === -1) {
+  if (releaseNotes && !OMIT_FROM_RELEASE_NOTES_KEYS.some((rx) => rx.test(releaseNotes))) {
     const splitNotes = releaseNotes.split('\n').filter((line) => line !== '');
     if (splitNotes.length > 0) {
       const quoted = splitNotes.map((line) => `> ${line}`).join('\n');


### PR DESCRIPTION
Fixes an issue surfaced in https://github.com/electron/electron/pull/25112#issuecomment-680465818.

More effectively checks for no-notes and also allows optional punctuation.

cc @nornagon @MarshallOfSound 