### PR TITLE
fix: don't trim null notes

### DIFF
--- a/src/__tests__/note.test.ts
+++ b/src/__tests__/note.test.ts
@@ -25,6 +25,13 @@ describe('comment generation', () => {
     expect(noteUtils.createPRCommentFromNotes('no-notes')).toEqual(constants.NO_NOTES_BODY);
   });
 
+  it('can handle missing notes', () => {
+    const note = noteUtils.findNoteInPRBody('oh no');
+    expect(noteUtils.createPRCommentFromNotes(note)).toEqual(constants.NO_NOTES_BODY);
+
+    expect(noteUtils.createPRCommentFromNotes('no-notes')).toEqual(constants.NO_NOTES_BODY);
+  });
+
   it('does not false positively match no-notes', () => {
     const surpriseNote = noteUtils.findNoteInPRBody(prBodyWithSurpriseNote);
     const comment = noteUtils.createPRCommentFromNotes(surpriseNote);

--- a/src/note-utils.ts
+++ b/src/note-utils.ts
@@ -15,14 +15,14 @@ export const findNoteInPRBody = (body: string): string | null => {
     notes = multilineMatch[1];
   }
 
-  // remove the default PR template
   if (notes) {
+    debug(`Found Notes: ${JSON.stringify(notes.trim())}`);
+
+    // Remove the default PR template.
     notes = notes.replace(/<!--.*?-->/g, '');
   }
 
-  debug(`Found Notes: ${JSON.stringify(notes.trim())}`);
-
-  return notes.trim();
+  return notes ? notes.trim() : notes;
 };
 
 const OMIT_FROM_RELEASE_NOTES_KEYS = [


### PR DESCRIPTION
Closes https://github.com/electron/clerk/issues/44.

Fixes an issue where we would call `notes.trim()` with a `notes` value of `null`, which throws.

cc @jkleinsc @MarshallOfSound @nornagon 