### PR TITLE
fix: sanitize notes in case of embedded html

### DIFF
--- a/src/__tests__/note.test.ts
+++ b/src/__tests__/note.test.ts
@@ -8,6 +8,11 @@ describe('note detection', () => {
   it('strips comments out of PR bodies', () => {
     expect(noteUtils.findNoteInPRBody(prBodyWithEmbeddedComment)).toEqual('no-notes');
   });
+  it('strips embedded html out of note bodies', () => {
+    const note = noteUtils.findNoteInPRBody(prBodyWithEmbeddedHtmlInNote);
+    expect(note).toContain('&lt;input file="type"&gt;');
+    expect(note).not.toContain('<input file="type">');
+  });
 });
 
 describe('comment generation', () => {
@@ -163,5 +168,16 @@ Notes:
 * fix 1px extending to secondary monitor
 * fix 1px overflowing into taskbar at certain resolutions
 * fix white line on top of window under 4k resolutions
+`;
+/* tslint:enable */
+
+// Source: https://github.com/electron/electron/pull/26217
+/* tslint:disable */
+const prBodyWithEmbeddedHtmlInNote = `Backport of #25030
+
+See that PR for details.
+
+
+Notes: Fixed an issue where packages could not be selected with <input file="type"> on macOS.
 `;
 /* tslint:enable */

--- a/src/note-utils.ts
+++ b/src/note-utils.ts
@@ -22,6 +22,19 @@ export const findNoteInPRBody = (body: string): string | null => {
     notes = notes.replace(/<!--.*?-->/g, '');
   }
 
+  if (notes) {
+    const sanitizeMap = new Map([
+      ['<', '&lt;'],
+      ['>', '&gt;'],
+    ]);
+    for (const [oldVal, newVal] of sanitizeMap.entries()) {
+      // TODO: use replaceAll when @node/types catches up to 15
+      while (notes.includes(oldVal)) {
+        notes = notes.replace(oldVal, newVal);
+      }
+    }
+  }
+
   return notes ? notes.trim() : notes;
 };
 


### PR DESCRIPTION
Replace `<` and `>` with `&lt;` and `&gt;` to prevent a note from accidentally embedding live html. :smile_cat: 

CC @codebytere 