### PR TITLE
fix:  bad regexes when matching no-notes variants

### DIFF
--- a/src/note-utils.ts
+++ b/src/note-utils.ts
@@ -45,8 +45,8 @@ const OMIT_FROM_RELEASE_NOTES_KEYS = [
   /^no.?$/,
   /^no-notes.?$/,
   /^no_notes.?$/,
-  /^`no-notes.?$`/,
-  /^`no notes.?$`/,
+  /^`no-notes.?`$/,
+  /^`no notes.?`$/,
   /^none.?$/,
   /^nothing.?$/,
 ];


### PR DESCRIPTION
Another small fix for warnings found at [LGTM](https://lgtm.com/projects/g/electron/clerk/?mode=list).

Looks like it might have just been a tyop that transposed `$` and `` ` `` on these lines:

```
  /^`no-notes.?$`/,
  /^`no notes.?$`/,
```

Since `$` matches end-of-line, neither of these would ever hit since they were looking for a backtick after end-of-line.