### PR TITLE
chore: fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global File Owners
-@electron/wg-releases
+* @electron/wg-releases


### PR DESCRIPTION
The current `.github/CODEOWNERS` doesn't seem correct, for example, it's not automatically assigning the WG as a reviewer