### PR TITLE
ci: fix SHA for actions/checkout

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@vac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3
     - name: Setup Node.js
       uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561  # tag: v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@vac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3
     - name: Setup Node.js
       uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561  # tag: v2
       with:


### PR DESCRIPTION
Follow-up to #87, had a copy-and-paste error in the SHA for `actions/checkout` where the `v` prefix from the tag stuck around.