### PR TITLE
chore: add private to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "electron-release-clerk",
   "version": "1.0.0",
+  "private": true,
   "main": "index.js",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Historically we've added `private` to any `package.json` we don't intend to publish. Add it here for consistency, and to make future scripts easier, like a script which audits repos for missing CFA setup or missing npm badge on the README.