### PR TITLE
chore: add another newline when editing Dependabot PRs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ const submitFeedbackForPR = async (
       await github.pulls.update(
         context.repo({
           pull_number: pr.number,
-          body: pr.body + '\n---\n\nNotes: none',
+          body: pr.body + '\n\n---\n\nNotes: none',
         }),
       );
       return;


### PR DESCRIPTION
#110 worked as intended, but the `---` wasn't rendering correctly because it needs an additional newline before it.