### PR TITLE
build: cleanup deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,14 +6,13 @@
   "license": "MIT",
   "dependencies": {
     "@octokit/rest": "^19.0.4",
+    "debug": "^4.3.4",
     "probot": "^12.3.3"
   },
   "devDependencies": {
-    "@types/bunyan": "^1.8.6",
     "@types/debug": "^4.1.12",
     "@types/jest": "^29.0.3",
     "@types/node": "^16.11.7",
-    "debug": "^4.3.4",
     "husky": "^8.0.0",
     "jest": "^29.0.3",
     "lint-staged": "^13.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1163,13 +1163,6 @@
   resolved "https://registry.yarnpkg.com/@types/btoa-lite/-/btoa-lite-1.0.0.tgz#e190a5a548e0b348adb0df9ac7fa5f1151c7cca4"
   integrity sha512-wJsiX1tosQ+J5+bY5LrSahHxr2wT+uME5UDwdN1kg4frt40euqA+wzECkmq4t5QbveHiJepfdThgQrPw6KiSlg==
 
-"@types/bunyan@^1.8.6":
-  version "1.8.6"
-  resolved "https://registry.yarnpkg.com/@types/bunyan/-/bunyan-1.8.6.tgz#6527641cca30bedec5feb9ab527b7803b8000582"
-  integrity sha512-YiozPOOsS6bIuz31ilYqR5SlLif4TBWsousN2aCWLi5233nZSX19tFbcQUPdR7xJ8ypPyxkCGNxg0CIV5n9qxQ==
-  dependencies:
-    "@types/node" "*"
-
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"


### PR DESCRIPTION
I believe `@types/bunyan` was included by mistake in the past, and `debug` needs to be moved from `devDependencies` to `dependencies` because it's used in the runtime code.