### PR TITLE
fix: no-notes explosion on some build PRs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { PullRequest } from '@octokit/webhooks-types/schema';
 import { Probot, Context } from 'probot';
 
-import * as noteUtils from './note-utils';
+import { createPRCommentFromNotes, findNoteInPRBody, updatePRBodyForNoNotes } from './note-utils';
 
 import d from 'debug';
 import { SEMANTIC_BUILD_PREFIX } from './constants';
@@ -12,7 +12,7 @@ const submitFeedbackForPR = async (
   pr: PullRequest,
   shouldComment = false,
 ) => {
-  const releaseNotes = pr.body != null && noteUtils.findNoteInPRBody(pr.body);
+  const releaseNotes = findNoteInPRBody(pr.body);
   const github = context.octokit;
 
   if (!releaseNotes) {
@@ -21,7 +21,7 @@ const submitFeedbackForPR = async (
       await github.pulls.update(
         context.repo({
           pull_number: pr.number,
-          body: pr.body + '\n\n---\n\nNotes: none',
+          body: updatePRBodyForNoNotes(pr.body),
         }),
       );
       return;
@@ -32,7 +32,7 @@ const submitFeedbackForPR = async (
       await github.pulls.update(
         context.repo({
           pull_number: pr.number,
-          body: pr.body + '\n\n---\n\nNotes: none',
+          body: updatePRBodyForNoNotes(pr.body),
         }),
       );
       return;
@@ -62,7 +62,7 @@ const submitFeedbackForPR = async (
       debug(`Creating comment from Release Notes.`);
       await github.issues.createComment(
         context.repo({
-          body: noteUtils.createPRCommentFromNotes(releaseNotes),
+          body: createPRCommentFromNotes(releaseNotes),
           issue_number: pr.number,
         }),
       );

--- a/src/note-utils.ts
+++ b/src/note-utils.ts
@@ -4,9 +4,26 @@ import * as constants from './constants';
 import d from 'debug';
 const debug = d('note-utils');
 
-export const findNoteInPRBody = (body: string): string | null => {
-  const onelineMatch = /(?:(?:\r?\n)|^)notes: (.+?)(?:(?:\r?\n)|$)/gi.exec(body);
-  const multilineMatch = /(?:(?:\r?\n?)Notes:(?:\r?\n+)((?:\*.+(?:(?:\r?\n)|$))+))/gi.exec(body);
+export const updatePRBodyForNoNotes = (body: string | null) => {
+  if (!body) return '';
+
+  let notesBody = body;
+  if (/(?:(?:\r?\n)|^)Notes: (.+?)(?:(?:\r?\n)|$)/gi.test(notesBody)) {
+    debug('Updating existing default notes template');
+    notesBody = notesBody.replace(/<!--.*?-->/g, 'none');
+  } else {
+    debug('Adding Notes: none to PR body');
+    notesBody += '\n\n---\n\nNotes: none';
+  }
+
+  return notesBody;
+};
+
+export const findNoteInPRBody = (body: string | null) => {
+  if (!body) return null;
+
+  const onelineMatch = /(?:(?:\r?\n)|^)Notes: (.+?)(?:(?:\r?\n)|$)/gi.exec(body);
+  const multilineMatch = /(?:(?:\r?\n)Notes:(?:\r?\n+)((?:\*.+(?:(?:\r?\n)|$))+))/gi.exec(body);
 
   let notes: string | null = null;
   if (onelineMatch?.[1]) {


### PR DESCRIPTION
Fixes the following no-notes explosion that could happen rarely:

![screenshot_2025-01-29_at_8 59 23___pm_720](https://github.com/user-attachments/assets/50e39a85-5a7f-447a-87ef-83e7640f96f1)

The root cause of this was that when `build` PRs had no-notes added to them automatically, it was appended to the end of the existing PR body, even if the PR still had the default notes template. This then triggered a new PR edit webhook, and existing logic only checked for the first instance of `Notes:`, which would still be the default notes template, and thus it would try to append again, ad infinitum.

Fix this by editing the default notes template if it exists and appending `Notes: none` otherwise.