### PR TITLE
build: remove postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "build": "tsc",
     "lint": "prettier --list-different \"{src,test}/**/*.{ts,tsx}\"",
     "prettier:write": "prettier --write \"{src,test}/**/*.{ts,tsx}\"",
-    "postinstall": "tsc",
     "start": "DEBUG=* probot run ./lib/index.js",
     "test": "vitest run",
     "test:watch": "vitest watch",


### PR DESCRIPTION
yarn@v4 seems to deterministically run this, but on heroku sometimes `tsc` is not around. Leaves the `build` script that heroku will run at the right time